### PR TITLE
Support castling move with NAG in FenParser.

### DIFF
--- a/FenParser0x88.php
+++ b/FenParser0x88.php
@@ -1259,7 +1259,7 @@ class FenParser0x88
                 case 0x03:
                 case 0x0B:
 
-                    if (substr($notation, 0, 3) === 'O-O' && substr($notation, 0, 3) !== 'O-O') {
+                    if (substr($notation, 0, 3) === 'O-O' && substr($notation, 0, 5) !== 'O-O-O') {
                         $foundPieces[] = ($offset + 4);
                         $ret['to'] = $offset + 6;
                     } else if (substr($notation, 0, 5) === 'O-O-O') {

--- a/FenParser0x88.php
+++ b/FenParser0x88.php
@@ -1259,10 +1259,10 @@ class FenParser0x88
                 case 0x03:
                 case 0x0B:
 
-                    if ($notation === 'O-O') {
+                    if (substr($notation, 0, 3) === 'O-O' && substr($notation, 0, 3) !== 'O-O') {
                         $foundPieces[] = ($offset + 4);
                         $ret['to'] = $offset + 6;
-                    } else if ($notation === 'O-O-O') {
+                    } else if (substr($notation, 0, 5) === 'O-O-O') {
                         $foundPieces[] = ($offset + 4);
                         $ret['to'] = $offset + 2;
                     } else {
@@ -1411,7 +1411,7 @@ class FenParser0x88
 
     function getPieceTypeByNotation($notation, $color = null)
     {
-        if ($notation === 'O-O-O' || $notation === 'O-O') {
+        if (substr($notation, 0, 5) === 'O-O-O' || substr($notation, 0, 3) === 'O-O') {
             $pieceType = 'K';
         } else {
             $token = substr($notation, 0, 1);
@@ -1813,3 +1813,4 @@ class FenParser0x88
 class FenParser0x88Exception extends Exception{
 
 }
+


### PR DESCRIPTION
Hi, loading a PGN with castling move with a NAG results in a hard crash on PHP 8.0.2. This PR should fix that.

PHP Error:
Fatal error: Uncaught Error: Unsupported operand types: string + int
in chessParser/FenParser0x88.php on line 1253

Sample code:
```
$pgn = '[Event "chessParser test"] [Site "test: Castling with NAG"] [Date "2021.02.16"] [Round "1"] [White "White player"] [Black "Black player"] [Result "*"] [PlyCount "12"] 1. e4 e5 2. d3 d6 3. Nc3 Nc6 4. Bd2 Bd7 5. Qe2 Qe7 6. O-O-O O-O-O= *';
$pgnparser = new PgnParser();
$pgnparser->setPgnContent($pgn);
$game = $pgnparser->getFirstGame();
```

